### PR TITLE
feat: Cram as input file format

### DIFF
--- a/.docker/v0.8.2/Dockerfile
+++ b/.docker/v0.8.2/Dockerfile
@@ -1,0 +1,95 @@
+FROM condaforge/miniforge3:latest
+LABEL io.github.snakemake.containerized="true"
+LABEL io.github.snakemake.conda_env_hash="146f9a9330d2c21dbe79d812695337058c829eb5c2a1a686b98a7a95d4da3c15"
+
+# Step 2: Retrieve conda environments
+
+# Conda environment:
+#   source: https://github.com/snakemake/snakemake-wrappers/raw/v5.2.1/bio/cutadapt/se/environment.yaml
+#   prefix: /conda-envs/7cffe387c7e7ef03de7e29fc51afc8f7
+#   channels:
+#     - conda-forge
+#     - bioconda
+#     - nodefaults
+#   dependencies:
+#     - cutadapt =4.9
+RUN mkdir -p /conda-envs/7cffe387c7e7ef03de7e29fc51afc8f7
+ADD https://github.com/snakemake/snakemake-wrappers/raw/v5.2.1/bio/cutadapt/se/environment.yaml /conda-envs/7cffe387c7e7ef03de7e29fc51afc8f7/environment.yaml
+
+# Conda environment:
+#   source: https://github.com/snakemake/snakemake-wrappers/raw/v5.2.1/bio/fastqc/environment.yaml
+#   prefix: /conda-envs/24b8923f8e4abe077ffe95b01bfc1652
+#   channels:
+#     - conda-forge
+#     - bioconda
+#     - nodefaults
+#   dependencies:
+#     - fastqc =0.12.1
+#     - snakemake-wrapper-utils =0.6.2
+RUN mkdir -p /conda-envs/24b8923f8e4abe077ffe95b01bfc1652
+ADD https://github.com/snakemake/snakemake-wrappers/raw/v5.2.1/bio/fastqc/environment.yaml /conda-envs/24b8923f8e4abe077ffe95b01bfc1652/environment.yaml
+
+# Conda environment:
+#   source: https://github.com/snakemake/snakemake-wrappers/raw/v5.2.1/bio/hisat2/index/environment.yaml
+#   prefix: /conda-envs/6bde2d6fbc33e1c614cc5b12e3191198
+#   channels:
+#     - conda-forge
+#     - bioconda
+#     - nodefaults
+#   dependencies:
+#     - hisat2 =2.2.1
+RUN mkdir -p /conda-envs/6bde2d6fbc33e1c614cc5b12e3191198
+ADD https://github.com/snakemake/snakemake-wrappers/raw/v5.2.1/bio/hisat2/index/environment.yaml /conda-envs/6bde2d6fbc33e1c614cc5b12e3191198/environment.yaml
+
+# Conda environment:
+#   source: https://github.com/snakemake/snakemake-wrappers/raw/v5.2.1/bio/multiqc/environment.yaml
+#   prefix: /conda-envs/9ab3161e947cc968897b9bb4302e9e45
+#   channels:
+#     - conda-forge
+#     - bioconda
+#     - nodefaults
+#   dependencies:
+#     - multiqc =1.25.2
+#     - snakemake-wrapper-utils =0.6.2
+RUN mkdir -p /conda-envs/9ab3161e947cc968897b9bb4302e9e45
+ADD https://github.com/snakemake/snakemake-wrappers/raw/v5.2.1/bio/multiqc/environment.yaml /conda-envs/9ab3161e947cc968897b9bb4302e9e45/environment.yaml
+
+# Conda environment:
+#   source: workflow/envs/stats.yaml
+#   prefix: /conda-envs/8fa2aaf0562a85d8af93d2d750206f15
+#   name: stats
+#   channels: 
+#     - conda-forge
+#     - bioconda
+#     - defaults
+#   dependencies:
+#     - r-tidyverse=2.0.0
+#     - r-cowplot=1.1.1
+#     - r-viridis=0.6.4
+#     - r-ggrepel=0.9.4
+#     - r-ineq=0.2_13
+#     - r-reshape2=1.4.4
+#     - bioconda::r-crisprcleanr=3.0.0
+#     - conda-forge::r-gprofiler2=0.2.3
+#     - python=3.10.12
+#     - mageck=0.5.9
+#     - numpy<1.24
+#     - pandas=2.0.3
+#     - scipy=1.11.1
+#     - scikit-learn=1.3.0
+#     - seaborn=0.12.2
+#     - click=8.1.7
+#     - hisat2=2.2.1
+#     - conda-forge::git=2.47.1
+#     - samtools=1.21
+RUN mkdir -p /conda-envs/8fa2aaf0562a85d8af93d2d750206f15
+COPY workflow/envs/stats.yaml /conda-envs/8fa2aaf0562a85d8af93d2d750206f15/environment.yaml
+
+# Step 3: Generate conda environments
+
+RUN conda env create --prefix /conda-envs/7cffe387c7e7ef03de7e29fc51afc8f7 --file /conda-envs/7cffe387c7e7ef03de7e29fc51afc8f7/environment.yaml && \
+    conda env create --prefix /conda-envs/24b8923f8e4abe077ffe95b01bfc1652 --file /conda-envs/24b8923f8e4abe077ffe95b01bfc1652/environment.yaml && \
+    conda env create --prefix /conda-envs/6bde2d6fbc33e1c614cc5b12e3191198 --file /conda-envs/6bde2d6fbc33e1c614cc5b12e3191198/environment.yaml && \
+    conda env create --prefix /conda-envs/9ab3161e947cc968897b9bb4302e9e45 --file /conda-envs/9ab3161e947cc968897b9bb4302e9e45/environment.yaml && \
+    conda env create --prefix /conda-envs/8fa2aaf0562a85d8af93d2d750206f15 --file /conda-envs/8fa2aaf0562a85d8af93d2d750206f15/environment.yaml && \
+    conda clean --all -y

--- a/workflow/envs/stats.yaml
+++ b/workflow/envs/stats.yaml
@@ -22,3 +22,4 @@ dependencies:
   - click=8.1.7
   - hisat2=2.2.1
   - conda-forge::git=2.47.1
+  - samtools=1.21

--- a/workflow/rules/count.smk
+++ b/workflow/rules/count.smk
@@ -11,6 +11,23 @@ rule create_fasta:
         "../scripts/csv_to_fasta.py"
 
 
+if cram():
+    rule cram2fastq:
+        input:
+            "reads/{sample}.cram",
+        output:
+            "reads/{sample}.fastq.gz",
+        log:
+            "logs/samtools-fastq/{sample}.interleaved.log",
+        params:
+            " ",
+        threads: 1
+        conda:
+            "../envs/stats.yaml"
+        shell:
+            "samtools fastq {input} 2> {log} | gzip -c > {output}"
+
+
 rule hisat2_index:
     input:
         fasta=fasta,

--- a/workflow/rules/count.smk
+++ b/workflow/rules/count.smk
@@ -12,7 +12,7 @@ rule create_fasta:
 
 
 if cram():
-    
+
     rule cram2fastq:
         input:
             "reads/{sample}.cram",

--- a/workflow/rules/count.smk
+++ b/workflow/rules/count.smk
@@ -12,6 +12,7 @@ rule create_fasta:
 
 
 if cram():
+    
     rule cram2fastq:
         input:
             "reads/{sample}.cram",

--- a/workflow/scripts/general_functions.smk
+++ b/workflow/scripts/general_functions.smk
@@ -159,11 +159,21 @@ def sample_names():
     Get sample names from fastq files and check for invalid characters
     """
     fastq = glob.glob("reads/*.fastq.gz")
+    cram = glob.glob("reads/*.cram")
+    if len(fastq) == 0 and len(cram) == 0:
+        raise ValueError("No fastq or cram files found in reads directory")
 
-    # Check if fastq files are present
-    assert len(fastq) != 0, "No fastq files (.fastq.gz) found in reads directory"
+    # Check which format is used
+    if len(fastq) > 0 and len(cram) > 0:
+        raise ValueError("Both fastq and cram files found in reads directory")
+    elif len(fastq) > 0:
+        ext = ".fastq.gz"
+        files = fastq
+    else:
+        ext = ".cram"
+        files = cram
 
-    sample_names = [os.path.basename(x).replace(".fastq.gz", "") for x in fastq]
+    sample_names = [os.path.basename(x).replace(ext, "") for x in files]
 
     # Check if this matches the samples in stats.csv
     # Check this now, otherwise it will fail later with MAGeCK
@@ -182,6 +192,19 @@ def sample_names():
         )
 
     return sample_names
+
+
+def cram():
+    """
+    Check if raw data is in CRAM format
+    """
+    # Check if CRAM files are present
+    cram = glob.glob("reads/*.cram")
+
+    if len(cram) > 0:
+        return True
+    else:
+        return False
 
 
 def comparisons():


### PR DESCRIPTION
Relating to issue #6 

Use .cram files as raw data in addition to .fastq.gz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for processing CRAM files, including automatic conversion to gzipped FASTQ format.
  - Introduced a new Docker image with multiple pre-configured bioinformatics environments for streamlined containerised workflows.

- **Bug Fixes**
  - Improved sample detection to handle both FASTQ and CRAM files, with error handling for mixed or missing formats.

- **Enhancements**
  - Updated the stats environment to include samtools v1.21 for enhanced file processing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->